### PR TITLE
fix(PostHog): exclude ingest path from language redirect

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,5 +8,5 @@ export const config = {
   // Match all pathnames except for
   // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
   // - … the ones containing a dot (e.g. `favicon.ico`)
-  matcher: '/((?!api|trpc|_next|_vercel|admin|.*\\..*).*)',
+  matcher: '/((?!api|trpc|_next|_vercel|admin|ingest|.*\\..*).*)',
 };


### PR DESCRIPTION
This pull request updates the route matching configuration in `src/proxy.ts` to exclude additional paths from being proxied.

Routing configuration update:

* The `matcher` pattern in `export const config` now also excludes paths starting with `/ingest`, in addition to the previously excluded paths (`/api`, `/trpc`, `/_next`, `/_vercel`, `/admin`, and any path containing a dot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated proxy configuration to exclude the 'ingest' endpoint from being proxied, refining which routes are handled by the middleware.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->