### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,8 @@
 name: PR
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/cavez86/portfolio/security/code-scanning/1](https://github.com/cavez86/portfolio/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block to restrict the `GITHUB_TOKEN` to the minimal scopes needed. Since this workflow only reads repository contents (via `actions/checkout`) and then runs local commands, it can safely set `contents: read`. The cleanest way is to add a root-level `permissions` block so it applies to all jobs (currently just `build`) without changing behavior.

Concretely, edit `.github/workflows/pr.yml` and insert a `permissions:` section near the top of the file, at the workflow level, e.g. after `name: PR` and before `on:`. Set it to `contents: read`. No imports, methods, or other definitions are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
